### PR TITLE
fix invalid physicalResourceId if any handler got exception

### DIFF
--- a/cfn_resource.py
+++ b/cfn_resource.py
@@ -38,6 +38,8 @@ def wrap_user_handler(func, base_response=None):
         }
         if event.get("PhysicalResourceId", False):
             response["PhysicalResourceId"] = event["PhysicalResourceId"]
+        else:
+            response["PhysicalResourceId"] = context.log_stream_name
 
         if base_response is not None:
             response.update(base_response)


### PR DESCRIPTION
When using this package, if the handler raise exception. The CFN stack just output "Invalid PhysicalResourceID" instead of output the real error message.

In the source code provided by AWS the physical resource ID is set to lambda logStreamName if not defined. 

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-lambda-function-code-cfnresponsemodule.html#cfn-lambda-function-code-cfnresponsemodule-source
